### PR TITLE
[FE]로그인 페이지 UI구현[TG-1]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "task-ground",
       "version": "0.1.0",
       "dependencies": {
+        "jose": "^6.1.2",
         "next": "16.0.3",
         "react": "19.2.0",
         "react-dom": "19.2.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1542,6 +1544,24 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4437,6 +4457,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.2.tgz",
+      "integrity": "sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "jose": "^6.1.2",
     "next": "16.0.3",
     "react": "19.2.0",
     "react-dom": "19.2.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import {signAccessToken, signRefreshToken} from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+    const { email, password } = await req.json();
+
+    if (email !== "test@test.com" || password !== "1234") {
+        return NextResponse.json(
+            { message: "이메일 또는 비밀번호가 올바르지 않습니다." },
+            { status: 401 }
+        );
+    }
+
+    const userId = "user-1";
+
+    const accessToken = await signAccessToken({ sub: userId, email });
+    const refreshToken = await signRefreshToken({ sub: userId, email });
+
+    const res = NextResponse.json({ message: "로그인 성공" });
+
+    res.cookies.set("access_token", accessToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 15, // 15분
+    });
+
+    res.cookies.set("refresh_token", refreshToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 60 * 24 * 7, // 7일
+    });
+
+    return res;
+}

--- a/src/app/auth/login/loginForm.tsx
+++ b/src/app/auth/login/loginForm.tsx
@@ -1,0 +1,83 @@
+'use client'
+import React, { useState } from 'react';
+
+const LoginForm = () => {
+    const [alertMessage, setAlertMessage] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        const formData = new FormData(e.currentTarget)
+        const email = formData.get('email')
+        const password = formData.get('password')
+
+        if (!email || !password) {
+            return setAlertMessage('이메일과 비밀번호를 정확히 입력해주세요.');
+        }
+
+        const res = await fetch('/api/login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({email,password}),
+        })
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            return setAlertMessage(
+                data.message || '로그인에 실패했습니다. 다시 시도해주세요.'
+            );
+        }
+        setAlertMessage('');
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-5 text-black relative">
+            <div>
+                <label className="block text-sm font-medium mb-1">이메일</label>
+                <input
+                    required
+                    name="email"
+                    type="email"
+                    placeholder="example@taskground.com"
+                    className="w-full border rounded-md px-3 py-2 focus:ring-2 focus:ring-black focus:outline-none"
+                />
+            </div>
+
+            <div>
+                <label className="block text-sm font-medium mb-1">비밀번호</label>
+                <input
+                    required
+                    name="password"
+                    type="password"
+                    placeholder="••••••••"
+                    className="w-full border rounded-md px-3 py-2 focus:ring-2 focus:ring-black focus:outline-none"
+                />
+            </div>
+
+            <button
+                type="submit"
+                className="w-full bg-black text-white py-2 rounded-md hover:bg-gray-800 transition font-medium"
+            >
+                로그인
+            </button>
+
+            <div
+                className={`transition-all duration-300 overflow-hidden ${
+                    alertMessage ? 'max-h-10' : 'max-h-0'
+                }`}
+            >
+                <p
+                    className={`text-red-500 text-[12px] text-center transition-all duration-300 ${
+                        alertMessage
+                            ? 'opacity-100 translate-y-0'
+                            : 'opacity-0 translate-y-2'
+                    }`}
+                >
+                    {alertMessage}
+                </p>
+            </div>
+        </form>
+    );
+};
+
+export default LoginForm;

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import LoginForm from "@/app/auth/login/loginForm";
+
+const Page = () => {
+    return (
+        <div className="min-h-screen flex items-center justify-center  bg-[#f7f7f8] px-4">
+            <div className="w-full max-w-sm bg-white p-8 rounded-2xl shadow-sm border border-gray-200">
+
+                <div className="text-center mb-8">
+                    <h1 className="text-3xl text-blue-400 font-extrabold tracking-tight">
+                        TASK <span className="text-black">GROUND</span>
+                    </h1>
+                    <p className="text-gray-500 text-sm mt-1">
+                        효율적인 작업을 위한 시작점
+                    </p>
+                </div>
+
+                <LoginForm/>
+
+                <div className="text-center text-sm text-gray-500 mt-6">
+                    계정이 없나요?{" "}
+                    <a href="/signup" className="text-black font-medium underline">
+                        회원가입
+                    </a>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Page;

--- a/src/app/auth/mypage/page.tsx
+++ b/src/app/auth/mypage/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Page = () => {
+    return (
+        <div>
+            
+        </div>
+    );
+};
+
+export default Page;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,64 +1,9 @@
-import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+    <div className="">
+      <main className="">
+        <h1></h1>
       </main>
     </div>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { SignJWT, jwtVerify, JWTPayload } from "jose";
+
+const secretKey = new TextEncoder().encode(process.env.JWT_SECRET!);
+const alg = "HS256";
+
+export async function signAccessToken(payload: JWTPayload) {
+    return new SignJWT(payload)
+        .setProtectedHeader({ alg })
+        .setIssuedAt()
+        .setExpirationTime("15m")
+        .sign(secretKey);
+}
+
+export async function signRefreshToken(payload: JWTPayload) {
+    return new SignJWT(payload)
+        .setProtectedHeader({ alg })
+        .setIssuedAt()
+        .setExpirationTime("7d")
+        .sign(secretKey);
+}
+
+export async function verifyToken(token: string) {
+    return jwtVerify(token, secretKey);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import {signAccessToken, verifyToken} from "@/lib/auth";
+
+const PUBLIC_PATHS = ["/auth/login", "/api/login", "/_next", "/favicon.ico"];
+
+function isPublicPath(pathname: string) {
+    return PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+}
+export async function proxy(req: NextRequest) {
+    const { pathname } = req.nextUrl;
+    if (isPublicPath(pathname)) {
+        return NextResponse.next();
+    }
+
+    const accessToken = req.cookies.get("access_token")?.value;
+    const refreshToken = req.cookies.get("refresh_token")?.value;
+
+    if (accessToken) {
+        try {
+            await verifyToken(accessToken);
+            return NextResponse.next();
+        } catch (err) {
+            // access 토큰이 만료/유효하지 않으면 아래에서 refresh 체크
+        }
+    }
+
+    if (refreshToken) {
+        try {
+            const { payload } = await verifyToken(refreshToken);
+
+            const newAccessToken = await signAccessToken({
+                sub: payload.sub,
+                email: payload.email,
+            });
+
+            const res = NextResponse.next();
+
+            res.cookies.set("access_token", newAccessToken, {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === "production",
+                sameSite: "lax",
+                path: "/",
+                maxAge: 60 * 15, // 15분
+            });
+
+            return res;
+        } catch (err) {
+            const loginUrl = new URL("/auth/login", req.url);
+            const res = NextResponse.redirect(loginUrl);
+            res.cookies.delete("access_token");
+            res.cookies.delete("refresh_token");
+            return res;
+        }
+    }
+
+    const loginUrl = new URL("/auth/login", req.url);
+    return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+    matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
[FE]로그인 페이지 UI구현[TG-1]

## 1. 📝 작업 개요 (Summary)

- 사용자가 이메일/비밀번호로 로그인할 수 있는 기본 로그인 UI/UX를 제공한다.
- 인증 로직과 연동될 수 있도록 폼 구조 및 에러 핸들링 UI를 완성한다.

## 2. 🔗 관련 이슈 (Related Issue)

- [FE] Next.js 에서 middleware가 동작하지 않는 현상 [TG-ISSUE-1]
https://www.notion.so/FE-Next-js-middleware-TG-ISSUE-1-2b057c64749980c480c4d308df122487?v=2b057c647499805093e4000c210393c4&source=copy_link

## 3. ✅ 변경 사항 (Changes)

- [x] 로그인 페이지 UI 추가
- [x] middleware -> proxy 변경
- [x] API 로그인 기능 구현

**주요 변경 내용:**

- `/api/login` 엔드포인트 추가 및 JWT 발급 로직 구현
-  로그인 폼 UI 및 유효성 검사 추가

## 4. 🧪 테스트 방법 (How to Test)

1. `npm run dev` / `pnpm dev`로 로컬 서버 실행
2. 브라우저에서 `http://localhost:3000/auth/login` 접속
3. 올바른 아이디/비밀번호 입력 후 로그인 버튼 클릭
4. 로그인 성공 시 메인 페이지로 이동하는지 확인

## 5. 📸 스크린샷 (Screenshots)

## 6. ✅ 체크리스트 (Checklist)

- [x] 로컬에서 빌드 및 기본 동작 확인 (`npm run build` / `pnpm build`)
- [x] 주요 기능에 대한 테스트 완료
- [x] **Breaking Changes**가 있을 경우 문서화 및 팀원 공유
- [x] PR 제목/내용이 변경 사항을 잘 설명함
