### PR TITLE
Dev -> main merge 워크 스페이스 기본 레이아웃 UI구현[TG-3]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "jose": "^6.1.2",
+        "lucide-react": "^0.554.0",
         "next": "16.0.3",
         "react": "19.2.0",
         "react-dom": "19.2.0"
@@ -4900,6 +4901,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.554.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.554.0.tgz",
+      "integrity": "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "jose": "^6.1.2",
+    "lucide-react": "^0.554.0",
     "next": "16.0.3",
     "react": "19.2.0",
     "react-dom": "19.2.0"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,24 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes slideDown {
+  0% {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes leftToRight {
+  0% {
+    opacity: 0;
+    transform: translatex(-8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translatex(0px);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} bg-[#f7f7f8] antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
       </body>

--- a/src/app/workspace/[id]/members/page.tsx
+++ b/src/app/workspace/[id]/members/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Page = () => {
+    return (
+        <div>
+            맴버 리스트 페이지
+        </div>
+    );
+};
+
+export default Page;

--- a/src/app/workspace/[id]/page.tsx
+++ b/src/app/workspace/[id]/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
+
+    return (
+        <div>
+            <h1 className="text-2xl font-bold">워크스페이스 대시보드</h1>
+            <p className="mt-2 text-gray-600">현재 workspace ID: {id}</p>
+        </div>
+    );
+}

--- a/src/app/workspace/[id]/settings/page.tsx
+++ b/src/app/workspace/[id]/settings/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Page = () => {
+    return (
+        <div>
+          설정 페이지
+        </div>
+    );
+};
+
+export default Page;

--- a/src/app/workspace/layout.tsx
+++ b/src/app/workspace/layout.tsx
@@ -1,0 +1,14 @@
+import Sidebar from "@/components/layout/sidebar";
+import Topbar from "@/components/layout/topbar";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="w-full min-h-screen flex bg-gray-50 text-black">
+            <Sidebar />
+            <div className="flex flex-col flex-1">
+                <Topbar />
+                <main className=" p-6">{children}</main>
+            </div>
+        </div>
+    );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
+import { Home, Users, Settings } from "lucide-react";
+
+export default function Sidebar() {
+    const pathname = usePathname();
+    const params = useParams<{ id?: string }>();
+    const workspaceId = params.id;
+
+    const NAV = [
+        { name: "대시보드", href: `/workspace/${workspaceId}`, icon: <Home size={18} /> },
+        { name: "멤버", href: `/workspace/${workspaceId}/members`, icon: <Users size={18} /> },
+        { name: "설정", href: `/workspace/${workspaceId}/settings`, icon: <Settings size={18} /> },
+    ];
+
+    return (
+        <aside className="hidden md:flex w-64 bg-white border-r border-gray-200 min-h-screen flex-col">
+            <div className="p-4 font-bold text-lg">Workspace {workspaceId}</div>
+
+            <nav className="mt-4 flex-1">
+                {NAV.map((item) => {
+                    const active = pathname === item.href;
+                    return (
+                        <Link key={item.href} href={item.href}>
+                            <div
+                                className={`flex items-center gap-3 px-4 py-3 cursor-pointer transition 
+                ${active ? "bg-blue-100 font-medium" : "hover:bg-blue-50"}`}
+                            >
+                                {item.icon}
+                                {item.name}
+                            </div>
+                        </Link>
+                    );
+                })}
+            </nav>
+
+            <div className="p-4 text-sm text-gray-600">© 2025 My App</div>
+        </aside>
+    );
+}

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useParams, usePathname } from "next/navigation";
+import Link from "next/link";
+import { Menu, X, Home, Users, Settings } from "lucide-react";
+
+export default function Topbar() {
+    const [wsOpen, setWsOpen] = useState(false);
+    const [mobileNavOpen, setMobileNavOpen] = useState(false);
+    const params = useParams<{ id?: string }>();
+    const pathname = usePathname();
+    const workspaceId = params.id;
+
+    const wsButtonRef = useRef<HTMLButtonElement | null>(null);
+    const wsDropdownRef = useRef<HTMLDivElement | null>(null);
+
+    const NAV = [
+        { name: "대시보드", href: `/workspace/${workspaceId}`, icon: <Home size={18} /> },
+        { name: "멤버", href: `/workspace/${workspaceId}/members`, icon: <Users size={18} /> },
+        { name: "설정", href: `/workspace/${workspaceId}/settings`, icon: <Settings size={18} /> },
+    ];
+
+    useEffect(() => {
+        if (!wsOpen) return;
+
+        function handleClickOutside(e: MouseEvent) {
+            const target = e.target as Node;
+            if (
+                wsButtonRef.current?.contains(target) ||
+                wsDropdownRef.current?.contains(target)
+            ) {
+                return;
+            }
+            setWsOpen(false);
+        }
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [wsOpen]);
+
+    return (
+        <header className="h-14 border-b bg-white flex items-center justify-between px-4 md:px-6 relative">
+            <button
+                ref={wsButtonRef}
+                onClick={() => setWsOpen((prev) => !prev)}
+                className="flex items-center gap-1 font-medium hover:bg-gray-100 px-3 py-1 rounded-md transition text-sm md:text-base"
+            >
+                현재 워크스페이스 : {workspaceId}
+            </button>
+
+            <div className="flex items-center gap-3">
+                <div className="hidden md:block w-8 h-8 rounded-full bg-gray-300" />
+
+                <button
+                    className="md:hidden p-2 rounded-md hover:bg-gray-100"
+                    onClick={() => setMobileNavOpen((prev) => !prev)}
+                >
+                    {mobileNavOpen ? <X size={20} /> : <Menu size={20} />}
+                </button>
+            </div>
+
+            {/* 모바일 네비 */}
+            {mobileNavOpen && (
+                <div className="fixed inset-0 z-40 md:hidden">
+                    <div
+                        className="absolute inset-0 bg-black/40"
+                        onClick={() => setMobileNavOpen(false)}
+                    />
+
+                    <div className="absolute top-14 left-0 w-64 h-[calc(100vh-56px)] bg-white shadow-lg flex flex-col animate-[leftToRight_0.2s_ease-out]">
+                        <div className="p-4 font-bold text-lg border-b">
+                            Workspace {workspaceId}
+                        </div>
+
+                        <nav className="mt-2 flex-1">
+                            {NAV.map((item) => {
+                                const active = pathname === item.href;
+                                return (
+                                    <Link
+                                        key={item.href}
+                                        href={item.href}
+                                        onClick={() => setMobileNavOpen(false)}
+                                    >
+                                        <div
+                                            className={`flex items-center gap-3 px-4 py-3 cursor-pointer text-sm transition 
+                      ${active ? "bg-gray-100 font-medium" : "hover:bg-gray-50"}`}
+                                        >
+                                            {item.icon}
+                                            {item.name}
+                                        </div>
+                                    </Link>
+                                );
+                            })}
+                        </nav>
+
+                        <div className="p-4 text-xs text-gray-500 border-t">© 2025 My App</div>
+                    </div>
+                </div>
+            )}
+            {wsOpen && (
+                <div
+                    ref={wsDropdownRef}
+                    className="
+            absolute top-16 left-4 md:left-6 bg-white shadow-md border rounded-md w-56
+            animate-[slideDown_0.2s_ease-out]
+          "
+                >
+                    <div className="p-2 border-b text-gray-500 text-sm">워크스페이스 전환</div>
+
+                    <Link href={`/workspace/1`} onClick={() => setWsOpen(false)}>
+                        <div className="w-full text-left px-3 py-2 hover:bg-gray-50">
+                            워크스페이스 1
+                        </div>
+                    </Link>
+
+                    <Link href={`/workspace/2`} onClick={() => setWsOpen(false)}>
+                        <div className="w-full text-left px-3 py-2 hover:bg-gray-50">
+                            워크스페이스 2
+                        </div>
+                    </Link>
+
+                    <div className="border-t mt-2">
+                        <button className="w-full text-left text-blue-600 px-3 py-2 hover:bg-blue-50">
+                            + 새 워크스페이스 생성
+                        </button>
+                    </div>
+                </div>
+            )}
+        </header>
+    );
+}


### PR DESCRIPTION
## 1. 📝 작업 개요 (Summary)

- 워크스페이스의 기본 레이아웃 UI 제작 

## 2. 🔗 관련 이슈 (Related Issue)

-

## 3. ✅ 변경 사항 (Changes)

- [x]  로그인 상태에서만 워크스페이스 UI를 접근할 수 있어야 한다.
- [x]  기본 레이아웃(사이드바 + 상단바)이 모든 관련 페이지에 적용되어야 한다.
- [x]  워크스페이스 목록이 UI에서 확인 가능해야 한다.
- [ ]  워크스페이스 생성 / 이름 변경 / 삭제 기능이 정상동작해야 한다.
- [ ]  워크스페이스 멤버 초대 / 멤버 리스트 확인 / 멤버 제거가 가능해야 한다.
- [x]  UX 기준에 맞는 모달, 드롭다운, 테이블 UI가 정상 작동해야 한다.
- [x]  모바일 버전 UI에서도 이용자가 사용 할 수 있어야 한다.

**주요 변경 내용:**

- 

## 4. 🧪 테스트 방법 (How to Test)

테스트 시나리오를 적어주세요.

1. /workspace/[id] 페이지 이동
2. 비로그인 상태 접근불가 확인
3. 워크스페이스 이름 클릭 시 이동 가능한 워크 스페이스 리스트 확인 가능.

## 5. 📸 스크린샷 (Screenshots)

## 6. ✅ 체크리스트 (Checklist)

- [x] 로컬에서 빌드 및 기본 동작 확인 (`npm run build` / `pnpm build`)
- [x] 주요 기능에 대한 테스트 완료
- [x] **Breaking Changes**가 있을 경우 문서화 및 팀원 공유
- [x] PR 제목/내용이 변경 사항을 잘 설명함
